### PR TITLE
et1x000: rename v3d-nxclient to nextv-cortexa15

### DIFF
--- a/conf/machine/et1x000.conf
+++ b/conf/machine/et1x000.conf
@@ -2,7 +2,7 @@
 #@NAME: Galaxy Innovations ET11000
 #@DESCRIPTION: Machine configuration for the Galaxy Innovations ET11000
 
-MACHINE_FEATURES += " textlcd 7segment dvb-c nextv-blindscan-dvbc mmc v3d-nxclient"
+MACHINE_FEATURES += " textlcd 7segment dvb-c nextv-blindscan-dvbc mmc nextv-cortexa15"
 OPENPLI_FEATURES += " ci"
 DISTRO_FEATURES_remove = "x11 wayland directfb"
 

--- a/conf/machine/include/nextv-arm.inc
+++ b/conf/machine/include/nextv-arm.inc
@@ -37,8 +37,6 @@ MACHINE_EXTRA_RRECOMMENDS = " \
 	ntfs-3g \
 	"
 
-EXTRA_OECMAKE_append_pn-kodi += " -DWITH_V3D=nxclient"
-
 PACKAGECONFIG_GL_pn-qtbase = " "
 PACKAGECONFIG_append_pn-qtbase += " gles2 linuxfb"
 

--- a/conf/machine/include/nextv-essential.inc
+++ b/conf/machine/include/nextv-essential.inc
@@ -1,6 +1,6 @@
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "\
 	kernel-module-cdfs \
-	${@bb.utils.contains('MACHINE_FEATURES', 'v3d-nxclient', 'nextv-v3ddriver-${MACHINE}' , '', d)} \
+	${@bb.utils.contains('MACHINE_FEATURES', 'nextv-cortexa15', 'nextv-v3ddriver-${MACHINE}' , '', d)} \
 	\
 	firmware-rtl8192eu \
 	firmware-rtl8188eu \


### PR DESCRIPTION
 -this split is following the naming used by OE-A and OpenPLi for kodi
 -remove the EXTRA_OECMAKE not necessary here

Signed-off-by: Andrea Adami <andrea.adami@gmail.com>